### PR TITLE
Ordered JavaScript libraries by today's relevance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 OneupUploaderBundle
 ===================
 
-The OneupUploaderBundle for Symfony2 adds support for handling file uploads using one of the following Javascript libraries, or [your own implementation](https://github.com/1up-lab/OneupUploaderBundle/blob/master/Resources/doc/custom_uploader.md).
+The OneupUploaderBundle for Symfony2 adds support for handling file uploads using one of the following JavaScript libraries, or [your own implementation](https://github.com/1up-lab/OneupUploaderBundle/blob/master/Resources/doc/custom_uploader.md).
 
-* [FineUploader](http://fineuploader.com/)
-* [jQuery File Uploader](http://blueimp.github.io/jQuery-File-Upload/)
-* [YUI3 Uploader](http://yuilibrary.com/yui/docs/uploader/)
-* [Uploadify](http://www.uploadify.com/)
-* [FancyUpload](http://digitarald.de/project/fancyupload/)
-* [MooUpload](https://github.com/juanparati/MooUpload)
-* [Plupload](http://www.plupload.com/)
+* [jQuery File Upload](http://blueimp.github.io/jQuery-File-Upload/)
 * [Dropzone](http://www.dropzonejs.com/)
+* [Plupload](http://www.plupload.com/)
+* [FineUploader](http://fineuploader.com/)
+* [FancyUpload](http://digitarald.de/project/fancyupload/) (based on MooTools)
+* [MooUpload](https://github.com/juanparati/MooUpload) (based on MooTools)
+* [YUI3 Uploader](http://yuilibrary.com/yui/docs/uploader/) (the YUI library is no longer maintained)
+* [UploadiFive](http://www.uploadify.com/) ($ 5.00)
+
 
 Features included:
 

--- a/Resources/doc/frontend_dropzone.md
+++ b/Resources/doc/frontend_dropzone.md
@@ -4,9 +4,9 @@ Use Dropzone in your Symfony2 application
 Download [Dropzone](http://www.dropzonejs.com/) and include it in your template. Connect the `action` property of the form to the dynamic route `_uploader_{mapping_name}`.
 
 ```html
-<script type="text/javascript" src="https://rawgithub.com/enyo/dropzone/master/downloads/dropzone.js"></script>
+<script type="text/javascript" src="https://raw.github.com/enyo/dropzone/master/dist/dropzone.js"></script>
 
-<form action="{{ oneup_uploader_endpoint('gallery') }}" class="dropzone">
+<form action="{{ oneup_uploader_endpoint('gallery') }}" class="dropzone" style="width:200px; height:200px; border:4px dashed black">
 </form>
 ```
 


### PR DESCRIPTION
Please update this in the project's discription too:
This Symfony2 bundle provides a server implementation for handling single and multiple file uploads using either FineUploader, jQuery File Uploader, YUI3 Uploader, Uploadify, FancyUpload, MooUpload, Plupload or Dropzone. Features include chunked uploads, orphanages and Gaufrette support.

I would even go further and mark the MooTools & YUI libraries as deprecated.